### PR TITLE
Use non-mutable references to handlers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ macro_rules! create_transform {
         pub fn $i<R, S, T, D>(
             input: &ArrayBase<R, D>,
             output: &mut ArrayBase<S, D>,
-            handler: &mut $h,
+            handler: &$h,
             axis: usize,
         ) where
             T: FftNum + FloatConst,
@@ -175,7 +175,7 @@ macro_rules! create_transform_par {
         pub fn $i<R, S, T, D>(
             input: &ArrayBase<R, D>,
             output: &mut ArrayBase<S, D>,
-            handler: &mut $h,
+            handler: &$h,
             axis: usize,
         ) where
             T: FftNum + FloatConst,
@@ -863,8 +863,10 @@ mod test {
         }
     }
 
-    fn approx_eq_complex<A, S, D>(result: &ArrayBase<S, D>, expected: &ArrayBase<S, D>)
-    where
+    fn approx_eq_complex<A, S, D>(
+        result: &ArrayBase<S, D>,
+        expected: &ArrayBase<S, D>,
+    ) where
         A: FftNum + std::fmt::Display + std::cmp::PartialOrd,
         S: ndarray::Data<Elem = Complex<A>>,
         D: Dimension,
@@ -921,7 +923,8 @@ mod test {
             [3.978, -0.962, -6.544, 1.154, 0.133, -2.229],
         ];
 
-        let mut solution: Array2<Complex<f64>> = Array2::zeros(solution_re.raw_dim());
+        let mut solution: Array2<Complex<f64>> =
+            Array2::zeros(solution_re.raw_dim());
         for (s, (s_re, s_im)) in solution
             .iter_mut()
             .zip(solution_re.iter().zip(solution_im.iter()))
@@ -968,7 +971,8 @@ mod test {
             [3.978, -0.962, -6.544, 1.154, 0.133, -2.229],
         ];
 
-        let mut solution: Array2<Complex<f64>> = Array2::zeros(solution_re.raw_dim());
+        let mut solution: Array2<Complex<f64>> =
+            Array2::zeros(solution_re.raw_dim());
         for (s, (s_re, s_im)) in solution
             .iter_mut()
             .zip(solution_re.iter().zip(solution_im.iter()))
@@ -1014,7 +1018,8 @@ mod test {
             [3.978, -0.962, -6.544, 1.154, 0.133, -2.229],
         ];
 
-        let mut solution: Array2<Complex<f64>> = Array2::zeros(solution_re.raw_dim());
+        let mut solution: Array2<Complex<f64>> =
+            Array2::zeros(solution_re.raw_dim());
         for (s, (s_re, s_im)) in solution
             .iter_mut()
             .zip(solution_re.iter().zip(solution_im.iter()))
@@ -1060,7 +1065,8 @@ mod test {
             [0., 0.633, -3.339, 0.],
         ];
 
-        let mut solution: Array2<Complex<f64>> = Array2::zeros(solution_re.raw_dim());
+        let mut solution: Array2<Complex<f64>> =
+            Array2::zeros(solution_re.raw_dim());
         for (s, (s_re, s_im)) in solution
             .iter_mut()
             .zip(solution_re.iter().zip(solution_im.iter()))
@@ -1107,7 +1113,8 @@ mod test {
             [0., 0.633, -3.339, 0.],
         ];
 
-        let mut solution: Array2<Complex<f64>> = Array2::zeros(solution_re.raw_dim());
+        let mut solution: Array2<Complex<f64>> =
+            Array2::zeros(solution_re.raw_dim());
         for (s, (s_re, s_im)) in solution
             .iter_mut()
             .zip(solution_re.iter().zip(solution_im.iter()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -863,10 +863,8 @@ mod test {
         }
     }
 
-    fn approx_eq_complex<A, S, D>(
-        result: &ArrayBase<S, D>,
-        expected: &ArrayBase<S, D>,
-    ) where
+    fn approx_eq_complex<A, S, D>(result: &ArrayBase<S, D>, expected: &ArrayBase<S, D>)
+    where
         A: FftNum + std::fmt::Display + std::cmp::PartialOrd,
         S: ndarray::Data<Elem = Complex<A>>,
         D: Dimension,
@@ -923,8 +921,7 @@ mod test {
             [3.978, -0.962, -6.544, 1.154, 0.133, -2.229],
         ];
 
-        let mut solution: Array2<Complex<f64>> =
-            Array2::zeros(solution_re.raw_dim());
+        let mut solution: Array2<Complex<f64>> = Array2::zeros(solution_re.raw_dim());
         for (s, (s_re, s_im)) in solution
             .iter_mut()
             .zip(solution_re.iter().zip(solution_im.iter()))
@@ -971,8 +968,7 @@ mod test {
             [3.978, -0.962, -6.544, 1.154, 0.133, -2.229],
         ];
 
-        let mut solution: Array2<Complex<f64>> =
-            Array2::zeros(solution_re.raw_dim());
+        let mut solution: Array2<Complex<f64>> = Array2::zeros(solution_re.raw_dim());
         for (s, (s_re, s_im)) in solution
             .iter_mut()
             .zip(solution_re.iter().zip(solution_im.iter()))
@@ -1018,8 +1014,7 @@ mod test {
             [3.978, -0.962, -6.544, 1.154, 0.133, -2.229],
         ];
 
-        let mut solution: Array2<Complex<f64>> =
-            Array2::zeros(solution_re.raw_dim());
+        let mut solution: Array2<Complex<f64>> = Array2::zeros(solution_re.raw_dim());
         for (s, (s_re, s_im)) in solution
             .iter_mut()
             .zip(solution_re.iter().zip(solution_im.iter()))
@@ -1065,8 +1060,7 @@ mod test {
             [0., 0.633, -3.339, 0.],
         ];
 
-        let mut solution: Array2<Complex<f64>> =
-            Array2::zeros(solution_re.raw_dim());
+        let mut solution: Array2<Complex<f64>> = Array2::zeros(solution_re.raw_dim());
         for (s, (s_re, s_im)) in solution
             .iter_mut()
             .zip(solution_re.iter().zip(solution_im.iter()))
@@ -1113,8 +1107,7 @@ mod test {
             [0., 0.633, -3.339, 0.],
         ];
 
-        let mut solution: Array2<Complex<f64>> =
-            Array2::zeros(solution_re.raw_dim());
+        let mut solution: Array2<Complex<f64>> = Array2::zeros(solution_re.raw_dim());
         for (s, (s_re, s_im)) in solution
             .iter_mut()
             .zip(solution_re.iter().zip(solution_im.iter()))


### PR DESCRIPTION
It seems like the `&mut` references to FFT handlers aren't necessary, as far as I can tell? They're annoying in my application that involves threads, since I had to put the handlers behind `Mutex`s, which is onerous and carries performance implications. Here I'm proposing to change `&mut` -> `&`. Let me know if I'm missing anything!

Also, thank you for making this crate! It's been very useful to me.